### PR TITLE
fix: use path.join to get jsonfile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,8 @@ module.exports = function(opts) {
         // loop array in the json file
         if (args[3].match(/^('|")[^']|[^"]('|")$/)) {
           // clean filename var and define path
-          var jsonfile = file.base + args[3].replace(/^('|")/, '').replace(/('|")$/, '')
+          var jsonPath = args[3].replace(/^('|")/, '').replace(/('|")$/, '');
+          var jsonfile = path.join(file.base, jsonPath);
           // check if json file exists
           if (fs.existsSync(jsonfile)) {
             // make sure we are getting the updated version of the json file


### PR DESCRIPTION
hello , i find a bug

this is my project folder
```
src
├── mock
│   └── data.json
└── views
    ├── index.html
    └── list.html
```
this is list.html
```
<div>
      @@loop("./components/card.html", "../mock/data.json")
</div>
```
but i get the err message :
```
 JSON file not exists: /Users/yuanweihai/Documents/chh/src/views../mock/data.json
```
so, i use the path.join, it work well.

```
/Users/yuanweihai/Documents/chh/src/mock/data.json
```

my english is very bad, can u understand what i written ?

